### PR TITLE
Fixed adding comment depending on language

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ intellij {
     version.set("2022.2.5")
     type.set("IC") // Target IDE Platform
 
-    plugins.set(listOf("com.intellij.java"))
+    plugins.set(listOf())
 }
 
 tasks {


### PR DESCRIPTION
### Изменения:
1) Теперь комментарий создаётся в зависимости от грамматики языка
2) Убрал лишний плагин (`java`)

### Дисклеймер:
Решение не лучшее, оно **не учитывает**, что в некоторых языках нет однострочного комментария (привет `CSS` с его `/* */`)

Lua с его `--`
<img width="387" alt="Screenshot 2023-09-23 at 18 11 26" src="https://github.com/polina4096/voices/assets/6605618/e272d879-4057-4c2f-9321-b141d51d3ba3">

Python с его `#`
<img width="393" alt="Screenshot 2023-09-23 at 18 11 52" src="https://github.com/polina4096/voices/assets/6605618/8f13c87f-74d9-442c-837b-b287ffabcb49">
